### PR TITLE
chore: disable shrink or grow memfd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ futures = { version = "0.3" }
 hyper-util = { version = "0.1" }
 moka = { version = "0.12", features = ["sync"] }
 nix = { version = "0.29", features = ["mman", "fs"] }
+once_cell = { version = "1.20" }
 passfd = { git = "https://github.com/polachok/passfd.git", rev = "d55881752c16aced1a49a75f9c428d38d3767213", features = ["async"] }
 prost = { version = "0.13" }
 uuid = { version = "1.7", features = ["v4"] }

--- a/src/consumer/session_manager.rs
+++ b/src/consumer/session_manager.rs
@@ -112,7 +112,7 @@ impl SessionManager {
         self.sessions.insert(key.into(), session);
     }
 
-    /// Get a session from the session manager and refresh the ttl.
+    /// Get a session from the session manager and refresh the tti.
     pub fn get(&self, key: &ClientId) -> Option<SessionRef> {
         self.sessions.get(key)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -62,6 +62,13 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display("Failed to fcntl"))]
+    Fcntl {
+        source: nix::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Tonic error"))]
     Tonic {
         source: tonic::Status,


### PR DESCRIPTION
This PR mainly makes the following changes
1. Shrink and grow memfd are not allowed.
2. When passing fd, there is no need to pass ringbuf len.
3. The len parameter in the ringbuf new function is removed.
4. Add check before recover ringbuf.