### PR TITLE
chore: add logs when creating or removing fd pass sock

### DIFF
--- a/src/fd_pass.rs
+++ b/src/fd_pass.rs
@@ -76,7 +76,7 @@ where
     pub async fn run(&mut self) -> Result<()> {
         if let Some(parent) = self.sock_path.parent() {
             fs::create_dir_all(parent).await.context(error::IoSnafu)?;
-            warn!(
+            info!(
                 "create the parent directory for the unix socket file: {:?}",
                 self.sock_path
             );
@@ -87,7 +87,7 @@ where
                 .await
                 .context(error::IoSnafu)?;
 
-            warn!("remove the unix socket file: {:?}", self.sock_path);
+            info!("remove the unix socket file: {:?}", self.sock_path);
         }
 
         let listener =

--- a/src/fd_pass.rs
+++ b/src/fd_pass.rs
@@ -17,9 +17,7 @@ use tokio::io::AsyncWriteExt;
 use tokio::net::UnixListener;
 use tokio::net::UnixStream;
 use tokio::time::sleep;
-use tracing::error;
-use tracing::info;
-use tracing::warn;
+use tracing::{error, info, warn};
 
 use crate::consumer::session_manager::Session;
 use crate::consumer::session_manager::SessionManagerRef;
@@ -78,6 +76,10 @@ where
     pub async fn run(&mut self) -> Result<()> {
         if let Some(parent) = self.sock_path.parent() {
             fs::create_dir_all(parent).await.context(error::IoSnafu)?;
+            warn!(
+                "create the parent directory for the unix socket file: {:?}",
+                self.sock_path
+            );
         }
 
         if self.sock_path.metadata().is_ok() {
@@ -85,7 +87,7 @@ where
                 .await
                 .context(error::IoSnafu)?;
 
-            info!("remove the unix socket file: {:?}", self.sock_path);
+            warn!("remove the unix socket file: {:?}", self.sock_path);
         }
 
         let listener =


### PR DESCRIPTION
To easily locate if `fd_pass_socket_path` is created or moved, I added a warning log when the parent directory of the unix socket file is created, and changed the removing log from `info` to `warn`.

The second change refers to the behavior of `start_grpc_server` on Edge.