### PR TITLE
feat: add decode method in DataProcess trait

### DIFF
--- a/src/consumer/process.rs
+++ b/src/consumer/process.rs
@@ -1,3 +1,4 @@
+use std::error::Error;
 use std::fmt::Debug;
 use std::future::Future;
 
@@ -6,9 +7,15 @@ use crate::error::DataProcessResult;
 use super::session_manager::SessionRef;
 
 pub trait DataProcess: Send + Sync {
+    type Message: Debug;
+
+    type Error: Error;
+
+    fn decode(&self, data: &[u8]) -> Result<Self::Message, Self::Error>;
+
     fn process(
         &self,
-        data: &[u8],
+        message: Self::Message,
         result_sender: ResultSender,
     ) -> impl Future<Output = ()>;
 }

--- a/src/consumer/process.rs
+++ b/src/consumer/process.rs
@@ -7,7 +7,7 @@ use crate::error::DataProcessResult;
 use super::session_manager::SessionRef;
 
 pub trait DataProcess: Send + Sync {
-    type Message: Debug;
+    type Message;
 
     type Error: Error;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -194,4 +194,4 @@ impl DataProcessResult {
 /// 100000 - 200000 are error codes used internally by shm-ringbuf and should
 /// not be used as business codes.
 pub const CHECKSUM_MISMATCH: u32 = 100000;
-pub const DECODE_ERROR: u32 = 10001;
+pub const DECODE_ERROR: u32 = 100001;

--- a/src/error.rs
+++ b/src/error.rs
@@ -194,3 +194,4 @@ impl DataProcessResult {
 /// 100000 - 200000 are error codes used internally by shm-ringbuf and should
 /// not be used as business codes.
 pub const CHECKSUM_MISMATCH: u32 = 100000;
+pub const DECODE_ERROR: u32 = 10001;

--- a/src/producer/fetch.rs
+++ b/src/producer/fetch.rs
@@ -78,6 +78,7 @@ impl ResultFetcher {
                 };
 
                 fetcher.inner.normal.store(false, Ordering::Relaxed);
+                fetcher.inner.subscriptions.clear();
                 sleep(fetcher.inner.retry_interval).await;
             }
         });

--- a/src/producer/fetch.rs
+++ b/src/producer/fetch.rs
@@ -78,7 +78,6 @@ impl ResultFetcher {
                 };
 
                 fetcher.inner.normal.store(false, Ordering::Relaxed);
-                fetcher.inner.subscriptions.clear();
                 sleep(fetcher.inner.retry_interval).await;
             }
         });


### PR DESCRIPTION
This pr mainly add `decode` method in `DataProcess` trait. 

Purpose: free the space of data block as soon as possible, which happens  after decode and  before the message process. Before this pr, it happens after data process.